### PR TITLE
docs: add critical MUI scroll lock conflict prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ function MyComponent() {
       <Drawer 
         open={drawerOpen}
         disableEnforceFocus={sheetOpen} // Disable when bottom sheet is open
+        disableScrollLock={!sheetOpen} // CRITICAL: Disable when bottom sheet is closed
       >
         {/* Drawer content */}
       </Drawer>
@@ -552,6 +553,8 @@ function MyComponent() {
   )
 }
 ```
+
+**⚠️ IMPORTANT**: When using `disableEnforceFocus={sheetOpen}`, you MUST also add `disableScrollLock={!sheetOpen}` to prevent scroll lock conflicts. Without this, if the MUI component closes first, there will be a conflict over who manages body scroll locking, leaving the page "frozen" with `overflow: hidden` until a page refresh.
 
 ### Portal-Rendered Components Inside Bottom Sheet
 


### PR DESCRIPTION
## Summary
- Add critical documentation about `disableScrollLock={\!sheetOpen}` requirement when using `disableEnforceFocus={sheetOpen}` with Material UI components
- Prevent scroll lock conflicts that leave pages "frozen" with `overflow: hidden`
- Update existing MUI integration example with proper configuration

## Problem
When using `disableEnforceFocus={sheetOpen}` with MUI components without the corresponding `disableScrollLock={\!sheetOpen}`, if the MUI component closes first, there's a conflict over who manages body scroll locking, leaving the page locked until refresh.

## Solution
- Added `disableScrollLock={\!sheetOpen}` to the MUI Drawer example
- Added prominent warning about the requirement
- Explains the consequences of not implementing this fix

## Test plan
- [x] Documentation updated with correct example
- [x] Warning message clearly explains the issue and solution
- [x] Code example demonstrates proper usage