### PR TITLE
fix: implement intelligent scroll lock conflict resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ This is a React component library that provides an accessible, animated bottom s
 - `useSnapPoints.tsx` - Snap point calculation and validation
 - `useFocusTrap.tsx` - Accessibility focus management
 - `useAriaHider.tsx` - ARIA screen reader management
-- `useScrollLock.tsx` - Body scroll prevention
+- `useScrollLock.tsx` - Body scroll prevention with conflict resolution
 - `useReady.tsx` - Component ready state management
 - `useReducedMotion.tsx` - Respects user motion preferences
 
@@ -99,3 +99,111 @@ Snap points are dynamically calculated based on content dimensions and can be cu
 
 ### Memory Management  
 The component is designed to mount on open and unmount on close to prevent memory leaks and ensure clean state.
+
+## Scroll Lock Conflict Resolution
+
+### Problem Context
+The library's scroll lock feature (`useScrollLock.tsx`) had critical conflicts with external UI libraries like Material UI that also manage body scroll styles.
+
+### Original Problem Flow
+```
+Step 1: MUI Drawer opens
+├── MUI sets: body.style.overflow = 'hidden'
+└── Page scroll: BLOCKED ✅
+
+Step 2: BottomSheet opens  
+├── We save: originalStyles.overflow = 'hidden' (MUI's value!)
+├── We set: body.style.overflow = 'hidden' (redundant)
+└── Page scroll: BLOCKED ✅
+
+Step 3: MUI Drawer closes
+├── MUI removes: body.style.overflow = ''
+└── Page scroll: UNBLOCKED ❌ (BottomSheet still open!)
+
+Step 4: BottomSheet closes
+├── We restore: body.style.overflow = 'hidden' (MUI's old value)
+└── Page scroll: BLOCKED FOREVER ❌❌
+```
+
+### Root Causes
+1. **Naive State Capture**: Saved external library's modified state as "original"
+2. **No Conflict Awareness**: No tracking of external changes during our lock period  
+3. **Blind Restoration**: Always restored saved state without context
+4. **No Active Maintenance**: Didn't maintain lock when external libraries interfered
+
+### Solution Architecture
+Implemented **MutationObserver-based intelligent conflict resolution**:
+
+```typescript
+interface ExternalStyleTracker {
+  observer: MutationObserver | null
+  originalStyles: Record<string, string> | null  // True original state
+  externallyModified: Set<string>                // Properties changed externally
+}
+```
+
+### Fixed Flow
+```
+Step 1: MUI Drawer opens
+├── MUI sets: body.style.overflow = 'hidden'
+└── Page scroll: BLOCKED ✅
+
+Step 2: BottomSheet opens
+├── We save: originalStyles.overflow = 'hidden' (current effective state)
+├── We save: inlineStyles.overflow = 'hidden' (MUI's inline style)  
+├── Start: MutationObserver monitoring body style changes
+├── We set: body.style.overflow = 'hidden' (maintain lock)
+└── Page scroll: BLOCKED ✅
+
+Step 3: MUI Drawer closes
+├── MUI removes: body.style.overflow = ''
+├── MutationObserver detects change
+├── We mark: externallyModified.add('overflow') 
+├── We immediately reapply: body.style.overflow = 'hidden'
+└── Page scroll: BLOCKED ✅ (maintained!)
+
+Step 4: BottomSheet closes
+├── Check: overflow in externallyModified? YES
+├── Action: body.style.removeProperty('overflow') (don't restore)
+├── Stop: MutationObserver
+└── Page scroll: UNBLOCKED ✅ (correct!)
+```
+
+### Key Implementation Details
+
+**Active Monitoring:**
+```typescript
+this.externalTracker.observer = new MutationObserver((mutations) => {
+  // If external library removed our overflow: hidden, reapply immediately
+  if (body.style.overflow !== 'hidden') {
+    this.externalTracker.externallyModified.add('overflow')
+    body.style.overflow = 'hidden'  // Maintain lock!
+  }
+})
+```
+
+**Intelligent Restoration:**
+```typescript
+// Special handling for overflow - if external library removed it, don't restore
+if (this.externalTracker.externallyModified.has('overflow')) {
+  body.style.removeProperty('overflow')  // Let external changes take effect
+} else {
+  body.style.overflow = originalValue    // Normal restoration
+}
+```
+
+### Testing Strategy
+Created comprehensive test page (`pages/mui-scroll-lock-test.tsx`) with:
+- Material UI v7.2 integration
+- Sequential interaction flow (Drawer → BottomSheet → close sequence)
+- Visual feedback for each step
+- Z-index conflict resolution
+- Both problematic and fixed behavior comparison
+
+### Compatibility Notes
+- **Backward Compatible**: No breaking changes to public API
+- **Platform Specific**: iOS uses different scroll lock strategy (`position: fixed`)
+- **Library Agnostic**: Works with any library that modifies body styles
+- **Performance**: MutationObserver only active during scroll lock period
+
+This solution resolves the fundamental conflict between concurrent scroll lock implementations while maintaining robust scroll prevention.

--- a/docs/Hero.tsx
+++ b/docs/Hero.tsx
@@ -34,6 +34,12 @@ const Links = ({ className }: { className?: string }) => (
     </Link>
     <Link
       className={className}
+      href="/mui-scroll-lock-test"
+    >
+      MUI Test
+    </Link>
+    <Link
+      className={className}
       href="https://github.com/wh1teee/react-spring-bottom-sheet-updated"
     >
       GitHub

--- a/docs/createEmotionCache.ts
+++ b/docs/createEmotionCache.ts
@@ -1,0 +1,19 @@
+import createCache from '@emotion/cache'
+
+const isBrowser = typeof document !== 'undefined'
+
+// On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
+// This assures that MUI styles are loaded first.
+// It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
+export default function createEmotionCache() {
+  let insertionPoint
+
+  if (isBrowser) {
+    const emotionInsertionPoint = document.querySelector<HTMLMetaElement>(
+      'meta[name="emotion-insertion-point"]',
+    )
+    insertionPoint = emotionInsertionPoint ?? undefined
+  }
+
+  return createCache({ key: 'mui-style', insertionPoint })
+}

--- a/docs/fixtures/ProblematicBottomSheet.tsx
+++ b/docs/fixtures/ProblematicBottomSheet.tsx
@@ -1,0 +1,36 @@
+import { forwardRef } from 'react'
+import { BottomSheet as OriginalBottomSheet, BottomSheetProps, BottomSheetRef } from '../../src'
+import { useProblematicScrollLock } from './useProblematicScrollLock'
+
+// BottomSheet wrapper that uses problematic scroll lock behavior
+export const ProblematicBottomSheet = forwardRef<
+  BottomSheetRef, 
+  BottomSheetProps & { useProblematic?: boolean }
+>(({ useProblematic = false, ...props }, ref) => {
+  const problematicScrollLockRef = useProblematicScrollLock({
+    enabled: useProblematic && !!props.open,
+  })
+
+  // If problematic mode is enabled, we'll use our problematic scroll lock
+  // and disable the built-in one
+  if (useProblematic) {
+    // Activate/deactivate problematic scroll lock based on open state
+    if (props.open) {
+      problematicScrollLockRef.current?.activate()
+    } else {
+      problematicScrollLockRef.current?.deactivate()
+    }
+
+    // Pass through props but disable the built-in scroll locking
+    return (
+      <OriginalBottomSheet
+        {...props}
+        scrollLocking={false} // Disable built-in scroll lock
+        ref={ref}
+      />
+    )
+  }
+
+  // Use normal behavior
+  return <OriginalBottomSheet {...props} ref={ref} />
+})

--- a/docs/fixtures/ProblematicBottomSheet.tsx
+++ b/docs/fixtures/ProblematicBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useEffect } from 'react'
 import { BottomSheet as OriginalBottomSheet, BottomSheetProps, BottomSheetRef } from '../../src'
 import { useProblematicScrollLock } from './useProblematicScrollLock'
 
@@ -8,20 +8,24 @@ export const ProblematicBottomSheet = forwardRef<
   BottomSheetProps & { useProblematic?: boolean }
 >(({ useProblematic = false, ...props }, ref) => {
   const problematicScrollLockRef = useProblematicScrollLock({
-    enabled: useProblematic && !!props.open,
+    enabled: useProblematic,
   })
 
-  // If problematic mode is enabled, we'll use our problematic scroll lock
-  // and disable the built-in one
-  if (useProblematic) {
-    // Activate/deactivate problematic scroll lock based on open state
-    if (props.open) {
-      problematicScrollLockRef.current?.activate()
-    } else {
-      problematicScrollLockRef.current?.deactivate()
+  // Use effect to handle open/close state changes
+  useEffect(() => {
+    if (useProblematic) {
+      if (props.open) {
+        // When opening: save current styles (which might be 'hidden' from MUI)
+        problematicScrollLockRef.current?.activate()
+      } else {
+        // When closing: restore saved styles (problematic restoration)
+        problematicScrollLockRef.current?.deactivate()
+      }
     }
+  }, [props.open, useProblematic, problematicScrollLockRef])
 
-    // Pass through props but disable the built-in scroll locking
+  // If problematic mode is enabled, disable the built-in scroll locking
+  if (useProblematic) {
     return (
       <OriginalBottomSheet
         {...props}
@@ -31,6 +35,6 @@ export const ProblematicBottomSheet = forwardRef<
     )
   }
 
-  // Use normal behavior
+  // Use normal behavior with built-in scroll lock handling
   return <OriginalBottomSheet {...props} ref={ref} />
 })

--- a/docs/fixtures/useProblematicScrollLock.tsx
+++ b/docs/fixtures/useProblematicScrollLock.tsx
@@ -1,0 +1,151 @@
+import { useDebugValue, useEffect, useRef, useCallback } from 'react'
+
+// Simplified version of old scroll lock behavior that causes conflicts
+interface OriginalStyles {
+  overflow: string
+  paddingRight: string
+  position?: string
+  top?: string
+  width?: string
+  scrollBehavior?: string
+}
+
+class ProblematicScrollLock {
+  private static instance: ProblematicScrollLock
+  private isLocked = false
+  private scrollOffset = 0
+  private originalStyles: OriginalStyles = {
+    overflow: '',
+    paddingRight: '',
+    position: '',
+    top: '',
+    width: '',
+    scrollBehavior: '',
+  }
+
+  static getInstance(): ProblematicScrollLock {
+    if (!ProblematicScrollLock.instance) {
+      ProblematicScrollLock.instance = new ProblematicScrollLock()
+    }
+    return ProblematicScrollLock.instance
+  }
+
+  private getScrollbarWidth(): number {
+    if (typeof window === 'undefined') return 0
+    return window.innerWidth - document.documentElement.clientWidth
+  }
+
+  // OLD BEHAVIOR: Only saves inline styles, not computed styles
+  private saveOriginalStyles(): void {
+    const { body } = document
+    this.originalStyles = {
+      overflow: body.style.overflow,
+      paddingRight: body.style.paddingRight,
+      position: body.style.position,
+      top: body.style.top,
+      width: body.style.width,
+      scrollBehavior: document.documentElement.style.scrollBehavior,
+    }
+  }
+
+  // OLD BEHAVIOR: Blindly restores whatever was saved
+  private restoreOriginalStyles(): void {
+    const { body } = document
+    const { documentElement } = document
+    
+    body.style.overflow = this.originalStyles.overflow
+    body.style.paddingRight = this.originalStyles.paddingRight
+    
+    body.style.position = this.originalStyles.position || ''
+    body.style.top = this.originalStyles.top || ''
+    body.style.width = this.originalStyles.width || ''
+    documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
+  }
+
+  lock(): void {
+    if (this.isLocked || typeof window === 'undefined') return
+
+    this.saveOriginalStyles()
+    this.isLocked = true
+
+    const { body } = document
+    const { documentElement } = document
+    const scrollbarWidth = this.getScrollbarWidth()
+
+    // Apply base scroll lock styles
+    body.style.overflow = 'hidden'
+    
+    // Compensate for scrollbar width if needed
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${scrollbarWidth}px`
+    }
+
+    // iOS-specific handling
+    this.scrollOffset = window.scrollY
+    documentElement.style.scrollBehavior = 'unset'
+    body.style.position = 'fixed'
+    body.style.top = `-${this.scrollOffset}px`
+    body.style.width = '100%'
+  }
+
+  unlock(): void {
+    if (!this.isLocked || typeof window === 'undefined') return
+
+    this.isLocked = false
+
+    // Restore original styles (this is where the problem occurs)
+    this.restoreOriginalStyles()
+
+    // iOS-specific scroll restoration
+    window.scrollTo(0, this.scrollOffset)
+    requestAnimationFrame(() => {
+      document.documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
+    })
+  }
+
+  isScrollLocked(): boolean {
+    return this.isLocked
+  }
+}
+
+export function useProblematicScrollLock({
+  enabled,
+}: {
+  enabled: boolean
+}) {
+  const ref = useRef<{ activate: () => void; deactivate: () => void }>({
+    activate: () => {
+      throw new TypeError('Tried to activate scroll lock too early')
+    },
+    deactivate: () => {},
+  })
+
+  const scrollLock = ProblematicScrollLock.getInstance()
+
+  useDebugValue(enabled ? 'Enabled (Problematic)' : 'Disabled')
+
+  const activate = useCallback(() => {
+    if (scrollLock.isScrollLocked()) return
+    scrollLock.lock()
+  }, [scrollLock])
+
+  const deactivate = useCallback(() => {
+    if (!scrollLock.isScrollLocked()) return
+    scrollLock.unlock()
+  }, [scrollLock])
+
+  useEffect(() => {
+    if (!enabled) {
+      ref.current.deactivate()
+      ref.current = { activate: () => {}, deactivate: () => {} }
+      return
+    }
+
+    ref.current = {
+      activate,
+      deactivate,
+    }
+  }, [enabled, activate, deactivate])
+
+  return ref
+}

--- a/docs/fixtures/useProblematicScrollLock.tsx
+++ b/docs/fixtures/useProblematicScrollLock.tsx
@@ -36,6 +36,8 @@ class ProblematicScrollLock {
   }
 
   // OLD BEHAVIOR: Only saves inline styles, not computed styles
+  // The key issue: if MUI already set overflow:hidden as inline style,
+  // we save that and later restore it, causing the freeze
   private saveOriginalStyles(): void {
     const { body } = document
     this.originalStyles = {
@@ -46,12 +48,22 @@ class ProblematicScrollLock {
       width: body.style.width,
       scrollBehavior: document.documentElement.style.scrollBehavior,
     }
+    console.log('🔴 Problematic: Saved styles:', {
+      inline: this.originalStyles.overflow || '(empty)',
+      computed: window.getComputedStyle(body).overflow,
+      problem: this.originalStyles.overflow === 'hidden' ? 'YES - will cause freeze!' : 'no'
+    })
   }
 
   // OLD BEHAVIOR: Blindly restores whatever was saved
   private restoreOriginalStyles(): void {
     const { body } = document
     const { documentElement } = document
+    
+    console.log('🔴 Problematic: Restoring styles:', {
+      restoring: this.originalStyles.overflow || '(empty)',
+      currentComputed: window.getComputedStyle(body).overflow
+    })
     
     body.style.overflow = this.originalStyles.overflow
     body.style.paddingRight = this.originalStyles.paddingRight
@@ -60,6 +72,11 @@ class ProblematicScrollLock {
     body.style.top = this.originalStyles.top || ''
     body.style.width = this.originalStyles.width || ''
     documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
+    
+    console.log('🔴 Problematic: After restore:', {
+      inline: body.style.overflow || '(empty)',
+      computed: window.getComputedStyle(body).overflow
+    })
   }
 
   lock(): void {
@@ -114,9 +131,7 @@ export function useProblematicScrollLock({
   enabled: boolean
 }) {
   const ref = useRef<{ activate: () => void; deactivate: () => void }>({
-    activate: () => {
-      throw new TypeError('Tried to activate scroll lock too early')
-    },
+    activate: () => {},
     deactivate: () => {},
   })
 
@@ -125,27 +140,30 @@ export function useProblematicScrollLock({
   useDebugValue(enabled ? 'Enabled (Problematic)' : 'Disabled')
 
   const activate = useCallback(() => {
+    if (!enabled) return
+    console.log('🔴 Problematic: Activating scroll lock, saving current styles:', {
+      overflow: document.body.style.overflow || '(empty)',
+      computed: window.getComputedStyle(document.body).overflow
+    })
     if (scrollLock.isScrollLocked()) return
     scrollLock.lock()
-  }, [scrollLock])
+  }, [scrollLock, enabled])
 
   const deactivate = useCallback(() => {
+    if (!enabled) return
+    console.log('🔴 Problematic: Deactivating scroll lock, restoring saved styles')
     if (!scrollLock.isScrollLocked()) return
     scrollLock.unlock()
-  }, [scrollLock])
+  }, [scrollLock, enabled])
 
+  // Don't automatically activate/deactivate based on enabled state
+  // Let the parent component control when to activate/deactivate
   useEffect(() => {
-    if (!enabled) {
-      ref.current.deactivate()
-      ref.current = { activate: () => {}, deactivate: () => {} }
-      return
-    }
-
     ref.current = {
       activate,
       deactivate,
     }
-  }, [enabled, activate, deactivate])
+  }, [activate, deactivate])
 
   return ref
 }

--- a/docs/theme.ts
+++ b/docs/theme.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { createTheme } from '@mui/material/styles'
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#dc004e',
+    },
+  },
+  typography: {
+    fontFamily: [
+      '-apple-system',
+      'BlinkMacSystemFont',
+      '"Segoe UI"',
+      'Roboto',
+      '"Helvetica Neue"',
+      'Arial',
+      'sans-serif',
+    ].join(','),
+  },
+})
+
+export default theme

--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
   ],
   "types": "dist/index.d.ts",
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.1.2",
+    "@mui/material": "^7.2.0",
+    "@mui/material-nextjs": "^7.1.1",
     "@radix-ui/react-portal": "^1.1.9",
     "@react-spring/web": "^10.0.1",
     "@use-gesture/react": "^10.3.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,8 +2,13 @@ import { inspect } from '@xstate/inspect'
 import type { InferGetStaticPropsType } from 'next'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
+import { ThemeProvider } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
+import { CacheProvider, EmotionCache } from '@emotion/react'
 import { capitalize } from '../docs/utils'
 import { debugging } from '../src/utils'
+import theme from '../docs/theme'
+import createEmotionCache from '../docs/createEmotionCache'
 
 import '../docs/style.css'
 import '../src/style.css'
@@ -49,13 +54,27 @@ export async function getStaticProps() {
 
 export type GetStaticProps = InferGetStaticPropsType<typeof getStaticProps>
 
-export default function _AppPage({ Component, pageProps }: AppProps) {
+// Client-side cache, shared for the whole session of the user in the browser.
+const clientSideEmotionCache = createEmotionCache()
+
+interface MyAppProps extends AppProps {
+  emotionCache?: EmotionCache
+}
+
+export default function _AppPage(props: MyAppProps) {
+  const { Component, emotionCache = clientSideEmotionCache, pageProps } = props
+  
   return (
-    <>
+    <CacheProvider value={emotionCache}>
       <Head>
         <meta name="viewport" content="width=device-width,viewport-fit=cover" />
+        <meta name="emotion-insertion-point" content="" />
       </Head>
-      <Component {...pageProps} />
-    </>
+      <ThemeProvider theme={theme}>
+        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+        <CssBaseline />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </CacheProvider>
   )
 }

--- a/pages/mui-scroll-lock-test.tsx
+++ b/pages/mui-scroll-lock-test.tsx
@@ -58,6 +58,43 @@ export default function MUIScrollLockTest() {
     <Box sx={{ width: drawerWidth }} role="presentation">
       <Toolbar />
       <Divider />
+      
+      <Box sx={{ p: 2 }}>
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          <AlertTitle>Step 1 Complete: Drawer Open</AlertTitle>
+          <Typography variant="body2">
+            MUI has set overflow:hidden on body. Now open the Bottom Sheet.
+          </Typography>
+        </Alert>
+        
+        <Button
+          variant="contained"
+          color="secondary"
+          fullWidth
+          onClick={() => setSheetOpen(true)}
+          disabled={sheetOpen}
+          sx={{ mb: 2 }}
+        >
+          2. Open Bottom Sheet
+        </Button>
+        
+        <FormControlLabel
+          control={
+            <Switch
+              checked={useProblematicBehavior}
+              onChange={(e) => setUseProblematicBehavior(e.target.checked)}
+              size="small"
+            />
+          }
+          label={
+            <Typography variant="caption">
+              Problematic Mode
+            </Typography>
+          }
+        />
+      </Box>
+      
+      <Divider />
       <List>
         {['Home', 'Settings', 'About'].map((text, index) => (
           <ListItem key={text} disablePadding>
@@ -146,48 +183,23 @@ export default function MUIScrollLockTest() {
         <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
           <Button
             variant="contained"
+            size="large"
             onClick={() => setDrawerOpen(true)}
             startIcon={<MenuIcon />}
+            disabled={drawerOpen}
           >
-            1. Open Drawer
+            1. Start Test - Open Drawer
           </Button>
-          <Button
-            variant="contained"
-            color="secondary"
-            onClick={() => setSheetOpen(true)}
-            disabled={!drawerOpen}
-          >
-            2. Open Bottom Sheet
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={() => setDrawerOpen(false)}
-            disabled={!drawerOpen || !sheetOpen}
-          >
-            3. Close Drawer
-          </Button>
-          <Button
-            variant="outlined"
-            color="error"
-            onClick={() => setSheetOpen(false)}
-            disabled={!sheetOpen || drawerOpen}
-          >
-            4. Close Bottom Sheet
-          </Button>
-        </Box>
-        
-        <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+          
           <Button
             variant="outlined"
             onClick={() => setDialogOpen(true)}
-            size="small"
           >
             Test Dialog
           </Button>
           <Button
             variant="outlined"
             onClick={() => setModalOpen(true)}
-            size="small"
           >
             Test Modal
           </Button>
@@ -199,7 +211,6 @@ export default function MUIScrollLockTest() {
               setDialogOpen(false)
               setModalOpen(false)
             }}
-            size="small"
           >
             Reset All
           </Button>
@@ -233,29 +244,58 @@ export default function MUIScrollLockTest() {
         useProblematic={useProblematicBehavior}
       >
         <Box sx={{ p: 3 }}>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            <AlertTitle>Step 2 Complete: Bottom Sheet Open</AlertTitle>
+            <Typography variant="body2">
+              {useProblematicBehavior 
+                ? "🔴 Problematic: Saved MUI's overflow:hidden as 'original'. Now close drawer first!"
+                : "✅ Fixed: Using new scroll lock with MutationObserver tracking."
+              }
+            </Typography>
+          </Alert>
+          
           <Typography variant="h6" gutterBottom>
-            Bottom Sheet Content
+            Scroll Lock Conflict Test
           </Typography>
-          <Typography variant="body1" paragraph>
-            This bottom sheet tests scroll lock behavior with MUI components.
+          
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Mode: {useProblematicBehavior ? "Problematic (old behavior)" : "Fixed (new behavior)"}
           </Typography>
-          <Typography variant="body2" color="text.secondary" paragraph>
-            Current mode: {useProblematicBehavior ? "Problematic (old)" : "Fixed (new)"}
-          </Typography>
-          <Box sx={{ mt: 2, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             <Button
-              variant="outlined"
+              variant="contained"
+              color="warning"
+              onClick={() => setDrawerOpen(false)}
+              disabled={!drawerOpen}
+              fullWidth
+            >
+              3. Close Drawer First
+            </Button>
+            
+            <Button
+              variant="contained"
+              color="error"
+              onClick={() => setSheetOpen(false)}
+              disabled={drawerOpen}
+              fullWidth
+            >
+              4. Close Bottom Sheet Last
+            </Button>
+            
+            <Divider sx={{ my: 1 }} />
+            
+            <Typography variant="caption" color="text.secondary">
+              After step 4, check if page scroll works. In problematic mode, 
+              page should be frozen (overflow:hidden restored incorrectly).
+            </Typography>
+            
+            <Button
+              variant="text"
               size="small"
               onClick={() => setDialogOpen(true)}
             >
-              Open Dialog from Sheet
-            </Button>
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={() => setSheetOpen(false)}
-            >
-              Close Sheet
+              Test Dialog
             </Button>
           </Box>
         </Box>

--- a/pages/mui-scroll-lock-test.tsx
+++ b/pages/mui-scroll-lock-test.tsx
@@ -114,13 +114,17 @@ export default function MUIScrollLockTest() {
         </Typography>
 
         <Alert severity="info" sx={{ mb: 3 }}>
-          <AlertTitle>Test Instructions</AlertTitle>
+          <AlertTitle>Test Instructions - Reproduce Scroll Lock Conflict</AlertTitle>
           <Typography variant="body2">
-            1. Toggle "Problematic Behavior" to test old vs new scroll lock handling<br/>
-            2. Open the drawer (menu button)<br/>
-            3. Open the bottom sheet<br/>
-            4. Close the drawer first, then the bottom sheet<br/>
-            5. Check if page scroll is working properly
+            <strong>To reproduce the problematic behavior:</strong><br/>
+            1. Enable "Problematic Behavior" toggle<br/>
+            2. Open the Drawer (menu button) - MUI sets overflow:hidden<br/>
+            3. Open the Bottom Sheet - saves MUI's overflow:hidden as "original"<br/>
+            4. Close the Drawer first - MUI removes its styles<br/>
+            5. Close the Bottom Sheet - restores the saved overflow:hidden ❌<br/>
+            6. Page should be frozen (can't scroll) in problematic mode<br/>
+            <br/>
+            <strong>With the fix disabled:</strong> Same steps but page scroll works correctly ✅
           </Typography>
         </Alert>
 
@@ -145,26 +149,59 @@ export default function MUIScrollLockTest() {
             onClick={() => setDrawerOpen(true)}
             startIcon={<MenuIcon />}
           >
-            Open Drawer
+            1. Open Drawer
           </Button>
           <Button
             variant="contained"
             color="secondary"
             onClick={() => setSheetOpen(true)}
+            disabled={!drawerOpen}
           >
-            Open Bottom Sheet
+            2. Open Bottom Sheet
           </Button>
           <Button
             variant="outlined"
-            onClick={() => setDialogOpen(true)}
+            onClick={() => setDrawerOpen(false)}
+            disabled={!drawerOpen || !sheetOpen}
           >
-            Open Dialog
+            3. Close Drawer
+          </Button>
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => setSheetOpen(false)}
+            disabled={!sheetOpen || drawerOpen}
+          >
+            4. Close Bottom Sheet
+          </Button>
+        </Box>
+        
+        <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+          <Button
+            variant="outlined"
+            onClick={() => setDialogOpen(true)}
+            size="small"
+          >
+            Test Dialog
           </Button>
           <Button
             variant="outlined"
             onClick={() => setModalOpen(true)}
+            size="small"
           >
-            Open Modal
+            Test Modal
+          </Button>
+          <Button
+            variant="text"
+            onClick={() => {
+              setDrawerOpen(false)
+              setSheetOpen(false)
+              setDialogOpen(false)
+              setModalOpen(false)
+            }}
+            size="small"
+          >
+            Reset All
           </Button>
         </Box>
 

--- a/pages/mui-scroll-lock-test.tsx
+++ b/pages/mui-scroll-lock-test.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Drawer,
+  AppBar,
+  Toolbar,
+  Typography,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Divider,
+  Paper,
+  Container,
+  Alert,
+  AlertTitle,
+  Switch,
+  FormControlLabel,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Modal,
+} from '@mui/material'
+import {
+  Menu as MenuIcon,
+  Home as HomeIcon,
+  Settings as SettingsIcon,
+  Info as InfoIcon,
+  Warning as WarningIcon,
+} from '@mui/icons-material'
+import { BottomSheet } from '../src'
+import { ProblematicBottomSheet } from '../docs/fixtures/ProblematicBottomSheet'
+
+const drawerWidth = 240
+
+export default function MUIScrollLockTest() {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [useProblematicBehavior, setUseProblematicBehavior] = useState(false)
+
+  // Generate long content to test scrolling
+  const longContent = Array.from({ length: 50 }, (_, i) => (
+    <Typography key={i} variant="body1" paragraph>
+      This is paragraph {i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+      Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim 
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    </Typography>
+  ))
+
+  const drawerContent = (
+    <Box sx={{ width: drawerWidth }} role="presentation">
+      <Toolbar />
+      <Divider />
+      <List>
+        {['Home', 'Settings', 'About'].map((text, index) => (
+          <ListItem key={text} disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                {index === 0 ? <HomeIcon /> : index === 1 ? <SettingsIcon /> : <InfoIcon />}
+              </ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  )
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+        <Toolbar>
+          <Button
+            color="inherit"
+            aria-label="open drawer"
+            onClick={() => setDrawerOpen(true)}
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </Button>
+          <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
+            MUI + Bottom Sheet Scroll Lock Test
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer
+        variant="temporary"
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        ModalProps={{
+          keepMounted: true, // Better open performance on mobile.
+        }}
+        sx={{
+          '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+        }}
+        // Test problematic vs fixed behavior
+        disableEnforceFocus={useProblematicBehavior ? false : sheetOpen}
+        {...(useProblematicBehavior ? {} : {})} // In the fixed version, we don't need disableScrollLock
+      >
+        {drawerContent}
+      </Drawer>
+
+      <Container component="main" sx={{ flexGrow: 1, p: 3, mt: 8 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Scroll Lock Conflict Test
+        </Typography>
+
+        <Alert severity="info" sx={{ mb: 3 }}>
+          <AlertTitle>Test Instructions</AlertTitle>
+          <Typography variant="body2">
+            1. Toggle "Problematic Behavior" to test old vs new scroll lock handling<br/>
+            2. Open the drawer (menu button)<br/>
+            3. Open the bottom sheet<br/>
+            4. Close the drawer first, then the bottom sheet<br/>
+            5. Check if page scroll is working properly
+          </Typography>
+        </Alert>
+
+        <Paper sx={{ p: 2, mb: 3 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={useProblematicBehavior}
+                onChange={(e) => setUseProblematicBehavior(e.target.checked)}
+              />
+            }
+            label="Use Problematic Behavior (old scroll lock handling)"
+          />
+          <Typography variant="caption" display="block" color="text.secondary">
+            When enabled, simulates the old behavior that caused scroll lock conflicts
+          </Typography>
+        </Paper>
+
+        <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+          <Button
+            variant="contained"
+            onClick={() => setDrawerOpen(true)}
+            startIcon={<MenuIcon />}
+          >
+            Open Drawer
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => setSheetOpen(true)}
+          >
+            Open Bottom Sheet
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => setDialogOpen(true)}
+          >
+            Open Dialog
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => setModalOpen(true)}
+          >
+            Open Modal
+          </Button>
+        </Box>
+
+        <Alert severity={useProblematicBehavior ? "warning" : "success"} sx={{ mb: 3 }}>
+          <AlertTitle>
+            {useProblematicBehavior ? "Problematic Mode Active" : "Fixed Mode Active"}
+          </AlertTitle>
+          {useProblematicBehavior 
+            ? "This simulates the old scroll lock behavior that could cause conflicts."
+            : "This uses the new scroll lock implementation with MutationObserver for conflict resolution."
+          }
+        </Alert>
+
+        <Typography variant="h5" gutterBottom>
+          Long Scrollable Content
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Scroll down to test that page scrolling works correctly after closing components.
+        </Typography>
+
+        {longContent}
+      </Container>
+
+      <ProblematicBottomSheet
+        open={sheetOpen}
+        onDismiss={() => setSheetOpen(false)}
+        defaultSnap={({ maxHeight }) => maxHeight / 2}
+        snapPoints={({ maxHeight }) => [maxHeight * 0.3, maxHeight * 0.6, maxHeight * 0.9]}
+        useProblematic={useProblematicBehavior}
+      >
+        <Box sx={{ p: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Bottom Sheet Content
+          </Typography>
+          <Typography variant="body1" paragraph>
+            This bottom sheet tests scroll lock behavior with MUI components.
+          </Typography>
+          <Typography variant="body2" color="text.secondary" paragraph>
+            Current mode: {useProblematicBehavior ? "Problematic (old)" : "Fixed (new)"}
+          </Typography>
+          <Box sx={{ mt: 2, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => setDialogOpen(true)}
+            >
+              Open Dialog from Sheet
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => setSheetOpen(false)}
+            >
+              Close Sheet
+            </Button>
+          </Box>
+        </Box>
+      </ProblematicBottomSheet>
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Test Dialog</DialogTitle>
+        <DialogContent>
+          <Typography>
+            This dialog also manages focus and can conflict with other components.
+            Test opening/closing in different orders with the drawer and bottom sheet.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Modal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        aria-labelledby="modal-title"
+      >
+        <Box sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: 400,
+          bgcolor: 'background.paper',
+          border: '2px solid #000',
+          boxShadow: 24,
+          p: 4,
+        }}>
+          <Typography id="modal-title" variant="h6" component="h2" gutterBottom>
+            Test Modal
+          </Typography>
+          <Typography sx={{ mt: 2 }}>
+            Another component that manages scroll locking and focus.
+          </Typography>
+          <Button
+            onClick={() => setModalOpen(false)}
+            sx={{ mt: 2 }}
+            variant="contained"
+          >
+            Close Modal
+          </Button>
+        </Box>
+      </Modal>
+    </Box>
+  )
+}

--- a/pages/mui-scroll-lock-test.tsx
+++ b/pages/mui-scroll-lock-test.tsx
@@ -242,6 +242,9 @@ export default function MUIScrollLockTest() {
         defaultSnap={({ maxHeight }) => maxHeight / 2}
         snapPoints={({ maxHeight }) => [maxHeight * 0.3, maxHeight * 0.6, maxHeight * 0.9]}
         useProblematic={useProblematicBehavior}
+        style={{
+          '--rsbs-z-index': '1400', // Higher than MUI Drawer (1200) and Modal (1300)
+        } as React.CSSProperties}
       >
         <Box sx={{ p: 3 }}>
           <Alert severity="info" sx={{ mb: 2 }}>
@@ -251,6 +254,13 @@ export default function MUIScrollLockTest() {
                 ? "🔴 Problematic: Saved MUI's overflow:hidden as 'original'. Now close drawer first!"
                 : "✅ Fixed: Using new scroll lock with MutationObserver tracking."
               }
+            </Typography>
+          </Alert>
+          
+          <Alert severity="success" sx={{ mb: 2 }}>
+            <Typography variant="caption">
+              ✅ Bottom Sheet is now on top of Drawer (z-index: 1400). 
+              You can see the drawer content behind but this sheet should be fully interactive.
             </Typography>
           </Alert>
           

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@emotion/cache':
+        specifier: ^11.14.0
+        version: 11.14.0
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.1.8)(react@19.1.0)
+      '@emotion/styled':
+        specifier: ^11.14.1
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
+      '@mui/icons-material':
+        specifier: ^7.1.2
+        version: 7.1.2(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
+      '@mui/material':
+        specifier: ^7.2.0
+        version: 7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@mui/material-nextjs':
+        specifier: ^7.1.1
+        version: 7.1.1(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-portal':
         specifier: ^1.1.9
         version: 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -985,6 +1003,60 @@ packages:
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+
+  '@emotion/cache@11.14.0':
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
+
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@emotion/is-prop-valid@1.3.1':
+    resolution: {integrity: sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/styled@11.14.1':
+    resolution: {integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0-rc.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+
+  '@emotion/weak-memoize@0.4.0':
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
+
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1188,6 +1260,115 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@mui/core-downloads-tracker@7.2.0':
+    resolution: {integrity: sha512-d49s7kEgI5iX40xb2YPazANvo7Bx0BLg/MNRwv+7BVpZUzXj1DaVCKlQTDex3gy/0jsCb4w7AY2uH4t4AJvSog==}
+
+  '@mui/icons-material@7.1.2':
+    resolution: {integrity: sha512-slqJByDub7Y1UcokrM17BoMBMvn8n7daXFXVoTv0MEH5k3sHjmsH8ql/Mt3s9vQ20cORDr83UZ448TEGcbrXtw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^7.1.2
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/material-nextjs@7.1.1':
+    resolution: {integrity: sha512-6/tjmViYMI7XIqDTqK+n4t5B07YfVDq72emdBy/o8FLHsV7u477Ro0Aago2MQu8FrBQWDvzvvRkynIb02GjDBQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/cache': ^11.11.0
+      '@emotion/react': ^11.11.4
+      '@emotion/server': ^11.11.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/cache':
+        optional: true
+      '@emotion/server':
+        optional: true
+      '@types/react':
+        optional: true
+
+  '@mui/material@7.2.0':
+    resolution: {integrity: sha512-NTuyFNen5Z2QY+I242MDZzXnFIVIR6ERxo7vntFi9K1wCgSwvIl0HcAO2OOydKqqKApE6omRiYhpny1ZhGuH7Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material-pigment-css': ^7.2.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@mui/material-pigment-css':
+        optional: true
+      '@types/react':
+        optional: true
+
+  '@mui/private-theming@7.2.0':
+    resolution: {integrity: sha512-y6N1Yt3T5RMxVFnCh6+zeSWBuQdNDm5/UlM0EAYZzZR/1u+XKJWYQmbpx4e+F+1EpkYi3Nk8KhPiQDi83M3zIw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/styled-engine@7.2.0':
+    resolution: {integrity: sha512-yq08xynbrNYcB1nBcW9Fn8/h/iniM3ewRguGJXPIAbHvxEF7Pz95kbEEOAAhwzxMX4okhzvHmk0DFuC5ayvgIQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/system@7.2.0':
+    resolution: {integrity: sha512-PG7cm/WluU6RAs+gNND2R9vDwNh+ERWxPkqTaiXQJGIFAyJ+VxhyKfzpdZNk0z0XdmBxxi9KhFOpgxjehf/O0A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+
+  '@mui/types@7.4.4':
+    resolution: {integrity: sha512-p63yhbX52MO/ajXC7hDHJA5yjzJekvWD3q4YDLl1rSg+OXLczMYPvTuSuviPRCgRX8+E42RXz1D/dz9SxPSlWg==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@7.2.0':
+    resolution: {integrity: sha512-O0i1GQL6MDzhKdy9iAu5Yr0Sz1wZjROH1o3aoztuivdCXqEeQYnEjTDiRLGuFxI9zrUbTHBwobMyQH5sNtyacw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
 
@@ -1334,6 +1515,9 @@ packages:
   '@pnpm/npm-conf@2.3.1':
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -1579,10 +1763,18 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
       '@types/react': ^19.0.0
+
+  '@types/react-transition-group@4.4.12':
+    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
@@ -2178,6 +2370,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
@@ -2258,6 +2454,9 @@ packages:
     resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
     engines: {node: '>=16'}
     hasBin: true
+
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2471,6 +2670,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
@@ -2843,6 +3045,9 @@ packages:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
     engines: {node: '>=8'}
 
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
   find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
@@ -3064,6 +3269,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   hook-std@3.0.0:
     resolution: {integrity: sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==}
@@ -4627,6 +4835,15 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@19.1.0:
+    resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -4920,6 +5137,10 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -5073,6 +5294,9 @@ packages:
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
+
+  stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -6442,6 +6666,89 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emotion/babel-plugin@11.13.5':
+    dependencies:
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/runtime': 7.27.6
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/cache@11.14.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      stylis: 4.2.0
+
+  '@emotion/hash@0.9.2': {}
+
+  '@emotion/is-prop-valid@1.3.1':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/serialize@1.3.3':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.1.3
+
+  '@emotion/sheet@1.4.0': {}
+
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.3.1
+      '@emotion/react': 11.14.0(@types/react@19.1.8)(react@19.1.0)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
+      '@emotion/utils': 1.4.2
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+
+  '@emotion/utils@1.4.2': {}
+
+  '@emotion/weak-memoize@0.4.0': {}
+
   '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0(jiti@1.21.7))':
     dependencies:
       eslint: 9.29.0(jiti@1.21.7)
@@ -6615,6 +6922,103 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@mui/core-downloads-tracker@7.2.0': {}
+
+  '@mui/icons-material@7.1.2(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/material': 7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@mui/material-nextjs@7.1.1(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@emotion/react': 11.14.0(@types/react@19.1.8)(react@19.1.0)
+      next: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@emotion/cache': 11.14.0
+      '@types/react': 19.1.8
+
+  '@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/core-downloads-tracker': 7.2.0
+      '@mui/system': 7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
+      '@mui/types': 7.4.4(@types/react@19.1.8)
+      '@mui/utils': 7.2.0(@types/react@19.1.8)(react@19.1.0)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.12(@types/react@19.1.8)
+      clsx: 2.1.1
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-is: 19.1.0
+      react-transition-group: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.1.8)(react@19.1.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
+      '@types/react': 19.1.8
+
+  '@mui/private-theming@7.2.0(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/utils': 7.2.0(@types/react@19.1.8)(react@19.1.0)
+      prop-types: 15.8.1
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@mui/styled-engine@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 19.1.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.1.8)(react@19.1.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
+
+  '@mui/system@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/private-theming': 7.2.0(@types/react@19.1.8)(react@19.1.0)
+      '@mui/styled-engine': 7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)
+      '@mui/types': 7.4.4(@types/react@19.1.8)
+      '@mui/utils': 7.2.0(@types/react@19.1.8)(react@19.1.0)
+      clsx: 2.1.1
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 19.1.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.1.8)(react@19.1.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
+      '@types/react': 19.1.8
+
+  '@mui/types@7.4.4(@types/react@19.1.8)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@mui/utils@7.2.0(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/types': 7.4.4(@types/react@19.1.8)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-is: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
       '@emnapi/core': 1.4.3
@@ -6748,6 +7152,8 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@popperjs/core@2.11.8': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
@@ -7051,7 +7457,13 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
+  '@types/prop-types@15.7.15': {}
+
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
+    dependencies:
+      '@types/react': 19.1.8
+
+  '@types/react-transition-group@4.4.12(@types/react@19.1.8)':
     dependencies:
       '@types/react': 19.1.8
 
@@ -7694,6 +8106,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -7777,6 +8191,8 @@ snapshots:
       is-text-path: 2.0.0
       meow: 12.1.1
       split2: 4.2.0
+
+  convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -8003,6 +8419,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.27.6
+      csstype: 3.1.3
 
   dom-serializer@1.4.1:
     dependencies:
@@ -8531,6 +8952,8 @@ snapshots:
       make-dir: 3.1.0
       pkg-dir: 4.2.0
 
+  find-root@1.1.0: {}
+
   find-up@2.1.0:
     dependencies:
       locate-path: 2.0.0
@@ -8775,6 +9198,10 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
 
   hook-std@3.0.0: {}
 
@@ -10285,6 +10712,17 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@19.1.0: {}
+
+  react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   react@19.1.0: {}
 
   read-cache@1.0.0:
@@ -10690,6 +11128,8 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
+  source-map@0.5.7: {}
+
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
@@ -10848,6 +11288,8 @@ snapshots:
       browserslist: 4.25.0
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
+
+  stylis@4.2.0: {}
 
   sucrase@3.35.0:
     dependencies:

--- a/src/hooks/useScrollLock.tsx
+++ b/src/hooks/useScrollLock.tsx
@@ -33,16 +33,18 @@ interface OriginalStyles {
   scrollBehavior?: string
 }
 
-// Track external style changes
+// Track external style changes for properties we modify
 interface ExternalStyleTracker {
   observer: MutationObserver | null
-  originalComputedStyles: {
+  originalStyles: {
     overflow: string
     paddingRight: string
     position: string
     top: string
     width: string
   } | null
+  // Track which properties were changed by external libraries while we were active
+  externallyModified: Set<string>
 }
 
 class ModernScrollLock {
@@ -60,7 +62,8 @@ class ModernScrollLock {
   private touchMoveHandler: ((e: TouchEvent) => void) | null = null
   private externalTracker: ExternalStyleTracker = {
     observer: null,
-    originalComputedStyles: null,
+    originalStyles: null,
+    externallyModified: new Set(),
   }
 
   static getInstance(): ModernScrollLock {
@@ -79,7 +82,17 @@ class ModernScrollLock {
     const { body } = document
     const computedStyles = window.getComputedStyle(body)
     
-    // Save inline styles (for our own changes)
+    // Save the current state of ALL properties we're about to modify
+    // This includes both inline and computed values
+    this.externalTracker.originalStyles = {
+      overflow: body.style.overflow || computedStyles.overflow,
+      paddingRight: body.style.paddingRight || computedStyles.paddingRight,
+      position: body.style.position || computedStyles.position,
+      top: body.style.top || computedStyles.top,
+      width: body.style.width || computedStyles.width,
+    }
+    
+    // Also save inline styles for our own restoration logic
     this.originalStyles = {
       overflow: body.style.overflow,
       paddingRight: body.style.paddingRight,
@@ -89,63 +102,106 @@ class ModernScrollLock {
       scrollBehavior: document.documentElement.style.scrollBehavior,
     }
     
-    // Save computed styles (the actual applied styles before our changes)
-    this.externalTracker.originalComputedStyles = {
-      overflow: computedStyles.overflow,
-      paddingRight: computedStyles.paddingRight,
-      position: computedStyles.position,
-      top: computedStyles.top,
-      width: computedStyles.width,
-    }
+    // Reset tracking
+    this.externalTracker.externallyModified.clear()
   }
 
   private restoreOriginalStyles(): void {
     const { body } = document
     const { documentElement } = document
     
-    // Check if external libraries changed styles while we were locked
-    const currentComputedStyles = window.getComputedStyle(body)
-    const shouldRestoreComputed = this.externalTracker.originalComputedStyles &&
-      currentComputedStyles.overflow !== this.externalTracker.originalComputedStyles.overflow
+    if (!this.externalTracker.originalStyles) return
     
-    // Remove our inline styles first
-    body.style.overflow = this.originalStyles.overflow
-    body.style.paddingRight = this.originalStyles.paddingRight
-    
-    if (isIOS) {
-      body.style.position = this.originalStyles.position || ''
-      body.style.top = this.originalStyles.top || ''
-      body.style.width = this.originalStyles.width || ''
-      documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
+    // Special handling for overflow - if external library removed it, don't restore to hidden
+    if (this.externalTracker.externallyModified.has('overflow')) {
+      // External library wanted to remove overflow, so we remove our inline style
+      // allowing their intention to take effect
+      body.style.removeProperty('overflow')
+    } else {
+      // Normal restoration for overflow
+      const originalValue = this.externalTracker.originalStyles!.overflow
+      if (this.originalStyles.overflow === '') {
+        body.style.removeProperty('overflow')
+      } else {
+        body.style.overflow = originalValue
+      }
     }
     
-    // If external library changed styles and they shouldn't be 'hidden', restore computed styles
-    if (shouldRestoreComputed && this.externalTracker.originalComputedStyles && 
-        this.externalTracker.originalComputedStyles.overflow !== 'hidden') {
-      // Only restore if computed style was not 'hidden' originally
-      if (body.style.overflow === '' || body.style.overflow === 'hidden') {
-        body.style.overflow = this.externalTracker.originalComputedStyles.overflow
+    // Handle other properties normally
+    const otherProperties = ['paddingRight', 'position', 'top', 'width'] as const
+    
+    otherProperties.forEach(prop => {
+      if (!this.externalTracker.externallyModified.has(prop)) {
+        const originalValue = this.externalTracker.originalStyles![prop]
+        
+        // If original value was from computed styles (not inline), remove the inline property
+        if (this.originalStyles[prop] === '') {
+          body.style.removeProperty(prop === 'paddingRight' ? 'padding-right' : prop)
+        } else {
+          // Restore the original inline value
+          ;(body.style as any)[prop] = originalValue
+        }
       }
+    })
+    
+    // Always restore scroll behavior on documentElement
+    if (isIOS) {
+      documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
+      
+      // Restore scroll position
+      window.scrollTo(0, this.scrollOffset)
+      requestAnimationFrame(() => {
+        documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
+      })
     }
   }
 
   private startTrackingExternalChanges(): void {
     if (typeof window === 'undefined' || this.externalTracker.observer) return
     
-    this.externalTracker.observer = new MutationObserver(() => {
-      // Update our snapshot of computed styles when external changes occur
-      if (this.isLocked && this.externalTracker.originalComputedStyles) {
-        const computedStyles = window.getComputedStyle(document.body)
-        // Only update if the change wasn't from us
-        if (computedStyles.overflow !== 'hidden') {
-          this.externalTracker.originalComputedStyles.overflow = computedStyles.overflow
+    this.externalTracker.observer = new MutationObserver((mutations) => {
+      if (!this.isLocked || !this.externalTracker.originalStyles) return
+      
+      mutations.forEach(mutation => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+          const { body } = document
+          
+          // If external library removed our overflow: hidden, reapply it immediately
+          // But mark that external library wanted to remove it (for proper restoration)
+          if (body.style.overflow !== 'hidden') {
+            this.externalTracker.externallyModified.add('overflow')
+            body.style.overflow = 'hidden'
+          }
+          
+          // Track changes for other properties
+          const currentStyles = window.getComputedStyle(body)
+          const otherProperties = ['paddingRight', 'position', 'top', 'width'] as const
+          
+          otherProperties.forEach(prop => {
+            const currentValue = prop === 'paddingRight' ? 
+              currentStyles.paddingRight : 
+              (currentStyles as any)[prop]
+            const originalValue = this.externalTracker.originalStyles![prop]
+            
+            if (currentValue !== originalValue) {
+              // Don't track our own changes as external
+              const isOurChange = (prop === 'paddingRight' && body.style.paddingRight !== '') ||
+                                (prop === 'position' && body.style.position === 'fixed') ||
+                                (prop === 'top' && body.style.top && body.style.top.includes('-')) ||
+                                (prop === 'width' && body.style.width === '100%')
+              
+              if (!isOurChange) {
+                this.externalTracker.externallyModified.add(prop)
+              }
+            }
+          })
         }
-      }
+      })
     })
     
     this.externalTracker.observer.observe(document.body, {
       attributes: true,
-      attributeFilter: ['style', 'class'],
+      attributeFilter: ['style'],
       subtree: false,
     })
   }
@@ -185,7 +241,7 @@ class ModernScrollLock {
     const { documentElement } = document
     const scrollbarWidth = this.getScrollbarWidth()
 
-    // Apply base scroll lock styles
+    // Apply scroll lock styles
     body.style.overflow = 'hidden'
     
     // Compensate for scrollbar width if needed
@@ -226,18 +282,8 @@ class ModernScrollLock {
     // Restore original styles
     this.restoreOriginalStyles()
 
-    // iOS-specific scroll restoration
-    if (isIOS) {
-      // Restore scroll position without smooth scrolling
-      window.scrollTo(0, this.scrollOffset)
-      // Restore smooth scrolling after a frame
-      requestAnimationFrame(() => {
-        document.documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
-      })
-    }
-    
     // Reset tracker
-    this.externalTracker.originalComputedStyles = null
+    this.externalTracker.originalStyles = null
   }
 
   isScrollLocked(): boolean {

--- a/src/hooks/useScrollLock.tsx
+++ b/src/hooks/useScrollLock.tsx
@@ -45,6 +45,8 @@ interface ExternalStyleTracker {
   } | null
   // Track which properties were changed by external libraries while we were active
   externallyModified: Set<string>
+  // Track our own applied values to distinguish from external changes
+  appliedByUs: Map<string, string>
 }
 
 class ModernScrollLock {
@@ -64,6 +66,7 @@ class ModernScrollLock {
     observer: null,
     originalStyles: null,
     externallyModified: new Set(),
+    appliedByUs: new Map(),
   }
 
   static getInstance(): ModernScrollLock {
@@ -104,6 +107,7 @@ class ModernScrollLock {
     
     // Reset tracking
     this.externalTracker.externallyModified.clear()
+    this.externalTracker.appliedByUs.clear()
   }
 
   private restoreOriginalStyles(): void {
@@ -138,18 +142,29 @@ class ModernScrollLock {
         if (this.originalStyles[prop] === '') {
           body.style.removeProperty(prop === 'paddingRight' ? 'padding-right' : prop)
         } else {
-          // Restore the original inline value
-          ;(body.style as any)[prop] = originalValue
+          // Restore the original inline value with type safety
+          if (prop === 'paddingRight') {
+            body.style.paddingRight = originalValue
+          } else if (prop === 'position') {
+            body.style.position = originalValue as any // position values are well-defined
+          } else if (prop === 'top') {
+            body.style.top = originalValue
+          } else if (prop === 'width') {
+            body.style.width = originalValue
+          }
         }
       }
     })
     
-    // Always restore scroll behavior on documentElement
+    // iOS-specific scroll restoration
     if (isIOS) {
-      documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
+      // Temporarily disable smooth scrolling for instant restoration
+      documentElement.style.scrollBehavior = 'auto'
       
       // Restore scroll position
       window.scrollTo(0, this.scrollOffset)
+      
+      // Restore original scroll behavior after position is set
       requestAnimationFrame(() => {
         documentElement.style.scrollBehavior = this.originalStyles.scrollBehavior || ''
       })
@@ -173,26 +188,17 @@ class ModernScrollLock {
             body.style.overflow = 'hidden'
           }
           
-          // Track changes for other properties
+          // Track changes for other properties using precise tracking
           const currentStyles = window.getComputedStyle(body)
           const otherProperties = ['paddingRight', 'position', 'top', 'width'] as const
           
           otherProperties.forEach(prop => {
-            const currentValue = prop === 'paddingRight' ? 
-              currentStyles.paddingRight : 
-              (currentStyles as any)[prop]
-            const originalValue = this.externalTracker.originalStyles![prop]
+            const currentInlineValue = body.style[prop as any]
+            const appliedByUsValue = this.externalTracker.appliedByUs.get(prop)
             
-            if (currentValue !== originalValue) {
-              // Don't track our own changes as external
-              const isOurChange = (prop === 'paddingRight' && body.style.paddingRight !== '') ||
-                                (prop === 'position' && body.style.position === 'fixed') ||
-                                (prop === 'top' && body.style.top && body.style.top.includes('-')) ||
-                                (prop === 'width' && body.style.width === '100%')
-              
-              if (!isOurChange) {
-                this.externalTracker.externallyModified.add(prop)
-              }
+            // If we applied a value but it's now different, external library changed it
+            if (appliedByUsValue && currentInlineValue !== appliedByUsValue) {
+              this.externalTracker.externallyModified.add(prop)
             }
           })
         }
@@ -241,12 +247,15 @@ class ModernScrollLock {
     const { documentElement } = document
     const scrollbarWidth = this.getScrollbarWidth()
 
-    // Apply scroll lock styles
+    // Apply scroll lock styles and track what we applied
     body.style.overflow = 'hidden'
+    this.externalTracker.appliedByUs.set('overflow', 'hidden')
     
     // Compensate for scrollbar width if needed
     if (options.reserveScrollBarGap && scrollbarWidth > 0) {
-      body.style.paddingRight = `${scrollbarWidth}px`
+      const paddingValue = `${scrollbarWidth}px`
+      body.style.paddingRight = paddingValue
+      this.externalTracker.appliedByUs.set('paddingRight', paddingValue)
     }
 
     // iOS-specific handling
@@ -256,6 +265,10 @@ class ModernScrollLock {
       body.style.position = 'fixed'
       body.style.top = `-${this.scrollOffset}px`
       body.style.width = '100%'
+      
+      this.externalTracker.appliedByUs.set('position', 'fixed')
+      this.externalTracker.appliedByUs.set('top', `-${this.scrollOffset}px`)
+      this.externalTracker.appliedByUs.set('width', '100%')
     }
 
     // Add touch event handler for iOS
@@ -284,6 +297,7 @@ class ModernScrollLock {
 
     // Reset tracker
     this.externalTracker.originalStyles = null
+    this.externalTracker.appliedByUs.clear()
   }
 
   isScrollLocked(): boolean {


### PR DESCRIPTION
## Summary

- Implements MutationObserver-based conflict resolution for scroll lock
- Maintains active scroll lock while bottom sheet is open, even when external libraries modify body styles
- Intelligently restores only non-conflicting styles when bottom sheet closes
- Fixes z-index layering issues with Material UI modals

## Problem Solved

Previously, when Material UI Drawer opened first and set `overflow: hidden`, then bottom sheet opened and saved that state, closing the Drawer would leave the page scrollable while bottom sheet was still open. Worse, when bottom sheet closed, it would restore the saved `overflow: hidden` state, freezing the page permanently.

## Technical Approach

1. **Active Monitoring**: MutationObserver tracks body style changes while scroll lock is active
2. **Aggressive Maintenance**: Immediately re-apply `overflow: hidden` if external libraries remove it
3. **Intelligent Restoration**: Track which properties were modified externally and skip restoring them
4. **Conflict Prevention**: Only restore styles that weren't changed by external libraries during the lock period

## Test Plan

- [x] Test with Material UI Drawer + Bottom Sheet conflict scenario
- [x] Verify scroll remains locked while bottom sheet is open
- [x] Verify scroll unlocks properly when bottom sheet closes
- [x] Verify no `overflow: hidden` persistence after full close
- [x] Test z-index layering with Material UI components

## Compatibility

- Maintains backward compatibility with existing scroll lock behavior
- No breaking changes to public API
- Only affects internal conflict resolution logic