### PR TITLE
fix: remove unused @ts-expect-error directive causing build failure

### DIFF
--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -145,6 +145,7 @@ export const BottomSheet = forwardRef<
   const focusTrapRef = useFocusTrap({
     targetRef: containerRef as React.RefObject<HTMLElement>,
     fallbackRef: overlayRef as React.RefObject<HTMLElement>,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Must convert false to undefined for focus trap
     initialFocusRef: initialFocusRef || undefined,
     enabled: ready && blocking && initialFocusRef !== false,
   })
@@ -690,7 +691,7 @@ export const BottomSheet = forwardRef<
           ...style,
           // Not overridable as the "focus lock with opacity 0" trick rely on it
           // @TODO the line below only fails on TS <4
-          // @ts-expect-error - Spring type mismatch with older TS versions
+          // Spring type compatibility for opacity property
           opacity: spring.ready,
         }
       } as any)}


### PR DESCRIPTION
- Removed unused @ts-expect-error directive on line 693 in BottomSheet.tsx
- Replaced with regular comment about spring type compatibility
- Added ESLint disable comment for focus trap nullish coalescing warning
- GitHub Actions build should now pass successfully

The @ts-expect-error directive was no longer needed as TypeScript resolved the type compatibility issue, making it an unused directive.